### PR TITLE
Updated the installation instructions for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Usage:  `./install.sh`  **[OPTIONS...]**
 ### Install from repository
 
 Archlinux:
+This package is available in the AUR
 
-    sudo pacman -S matcha-gtk-theme
+    yay -S matcha-gtk-theme
 
 FreeBSD:
 


### PR DESCRIPTION
Correcting the installation instructions for Arch Linux to address [issue #132](https://github.com/vinceliuice/Matcha-gtk-theme/issues/132).